### PR TITLE
feat: implement RGBA5551 (ARGB1555) PAA decoding

### DIFF
--- a/arma-file-formats/src/real_virtuality/paa/mipmap.rs
+++ b/arma-file-formats/src/real_virtuality/paa/mipmap.rs
@@ -140,7 +140,35 @@ impl Mipmap {
 
                 self.data = rgba_buf;
             }
-            PaaType::RGBA5551 => todo!(),
+            PaaType::RGBA5551 => {
+                let mut cursor_data = Cursor::new(&self.data);
+
+                let (_, decompressed_data) = decompress_lzss(
+                    &mut cursor_data,
+                    self.width as usize * self.height as usize * 2,
+                    true,
+                )?;
+
+                let mut rgba_buf =
+                    Vec::with_capacity(self.width as usize * self.height as usize * 4);
+
+                for i in (0..decompressed_data.len()).step_by(2) {
+                    let pixel =
+                        u16::from(decompressed_data[i]) | (u16::from(decompressed_data[i + 1]) << 8);
+
+                    let b = ((u32::from(pixel & 0x1F) * 255) / 31) as u8;
+                    let g = ((u32::from((pixel >> 5) & 0x1F) * 255) / 31) as u8;
+                    let r = ((u32::from((pixel >> 10) & 0x1F) * 255) / 31) as u8;
+                    let a = if pixel & 0x8000 != 0 { 255u8 } else { 0u8 };
+
+                    rgba_buf.push(r);
+                    rgba_buf.push(g);
+                    rgba_buf.push(b);
+                    rgba_buf.push(a);
+                }
+
+                self.data = rgba_buf;
+            }
             PaaType::RGBA8888 => todo!(),
             PaaType::GRAYwAlpha => {
                 let mut cursor_data = Cursor::new(&self.data);


### PR DESCRIPTION
## Summary
- Adds read/decode support for `RGBA5551` (`0x1555`) PAA textures
- Uses LZSS decompression followed by expanding 16-bit ARGB1555 pixels to 32-bit RGBA8888
- Bit layout: `A(1) R(5) G(5) B(5)` in a little-endian u16

## Context
The K9S_Djalka map ([Steam Workshop #1990519900](https://steamcommunity.com/sharedfiles/filedetails/?id=1990519900)) uses RGBA5551 for its `pictureMap_ca.paa`. Previously this hit a `todo!()` panic in `decompress_data()`, crashing any application using this library to decode that file.

## Implementation
Follows the same pattern as the existing `RGBA4444` decoder:
1. LZSS decompress the raw data (`width * height * 2` bytes)
2. Read each 16-bit pixel as little-endian
3. Extract and scale channels: R/G/B from 5-bit (0-31) to 8-bit (0-255), A from 1-bit to 0/255
4. Output as RGBA8888

Write support for RGBA5551 is left as `todo!()` (unchanged).